### PR TITLE
Clear the environment before setting container environment.

### DIFF
--- a/src/exec.c
+++ b/src/exec.c
@@ -492,6 +492,9 @@ static int hyper_do_exec_cmd(struct hyper_exec *exec, int pipe, struct stdio_con
 		goto out;
 	}
 
+	// Clear process environment
+	clearenv();
+
 	/* TODO: merge container env to exec env in hyperd */
 	if (hyper_setup_env(c->exec.envs, c->exec.envs_num) < 0) {
 		fprintf(stderr, "setup container envs for exec failed\n");


### PR DESCRIPTION
This ensures that there are no erroneous env variables left over by
any subsystem before the container and process specific env
variables are applied.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>