### PR TITLE
Do not try to kill a container when it was already finished

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -615,6 +615,14 @@ static int hyper_kill_container(char *json, int length)
 	c = hyper_find_container(pod, id);
 	if (c == NULL) {
 		fprintf(stderr, "can not find container whose id is %s\n", id);
+		/* if pod's init pid is 0 means container was already
+		 * cleaned there are not processes running, kill container
+		 * is not needed
+		 */
+		if (pod->init_pid == 0) {
+			fprintf(stdout, "container %s was already cleaned\n", id);
+			ret = 0;
+		}
 		goto out;
 	}
 


### PR DESCRIPTION
when a pod is created hyperstart assigns a init pid to it
once workload has finished hyperstart kills all processes running
in workload's namespace when this task is completed hyperstart checks
its ref counter if it is 0 then hyperstart cleans the pod
(umount devices, remove directories, etc) and sets the pod's init pid
to 0

Signed-off-by: Julio Montes <julio.montes@intel.com>