### PR TITLE
add support to change console size in newcontainer

### DIFF
--- a/src/exec.c
+++ b/src/exec.c
@@ -621,6 +621,11 @@ int hyper_run_process(struct hyper_exec *exec)
 		goto out;
 	}
 
+	if (exec->ptyfd >= 0 && set_win_size(exec->ptyfd, exec->rows, exec->columns) < 0) {
+		fprintf(stderr, "set win size failed");
+		goto out;
+	}
+
 	if (pipe2(pipe, O_CLOEXEC) < 0) {
 		perror("create pipe between pod init execcmd failed");
 		goto close_tty;

--- a/src/exec.h
+++ b/src/exec.h
@@ -39,6 +39,8 @@ struct hyper_exec {
 	uint64_t		seq;
 	uint64_t		errseq;
 	char			*workdir;
+	int 			rows;
+	int 			columns;
 };
 
 struct hyper_pod;

--- a/src/init.c
+++ b/src/init.c
@@ -49,9 +49,8 @@ static int hyper_handle_exit(struct hyper_pod *pod);
 
 static int hyper_set_win_size(char *json, int length)
 {
-	struct winsize size;
 	struct hyper_exec *exec;
-	int ret;
+	int ret, columns, rows;
 
 	fprintf(stdout, "call hyper_win_size, json %s, len %d\n", json, length);
 	JSON_Value *value = hyper_json_parse(json, length);
@@ -69,12 +68,10 @@ static int hyper_set_win_size(char *json, int length)
 		goto out;
 	}
 
-	size.ws_row = (int)json_object_get_number(json_object(value), "row");
-	size.ws_col = (int)json_object_get_number(json_object(value), "column");
+	rows = (int)json_object_get_number(json_object(value), "row");
+	columns = (int)json_object_get_number(json_object(value), "column");
 
-	ret = ioctl(exec->ptyfd, TIOCSWINSZ, &size);
-	if (ret < 0)
-		perror("cannot ioctl to set pty device term size");
+	ret = set_win_size(exec->ptyfd, rows, columns);
 
 out:
 	json_value_free(value);

--- a/src/parse.c
+++ b/src/parse.c
@@ -516,6 +516,14 @@ static int hyper_parse_process(struct hyper_exec *exec, char *json, jsmntok_t *t
 			exec->workdir = (json_token_str(json, &toks[++i]));
 			fprintf(stdout, "container workdir %s\n", exec->workdir);
 			i++;
+		} else if (json_token_streq(json, t, "rows") && t->size == 1) {
+			exec->rows = json_token_int(json, &toks[++i]);
+			fprintf(stdout, "container rows %d\n", exec->rows);
+			i++;
+		}  else if (json_token_streq(json, t, "columns") && t->size == 1) {
+			exec->columns = json_token_int(json, &toks[++i]);
+			fprintf(stdout, "container columns %d\n", exec->columns);
+			i++;
 		}
 	}
 

--- a/src/util.c
+++ b/src/util.c
@@ -819,3 +819,18 @@ ssize_t nonblock_read(int fd, void *buf, size_t count)
 
 	return len > 0 ? len : ret;
 }
+
+int set_win_size(int fd, int rows, int columns)
+{
+	int ret;
+	struct winsize size = {
+		.ws_row = rows,
+		.ws_col = columns,
+	};
+
+	ret = ioctl(fd, TIOCSWINSZ, &size);
+	if (ret < 0) {
+		perror("cannot ioctl to set pty device term size");
+	}
+	return ret;
+}

--- a/src/util.h
+++ b/src/util.h
@@ -44,4 +44,5 @@ struct passwd *hyper_getpwnam(const char *name);
 struct group *hyper_getgrnam(const char *name);
 int hyper_getgrouplist(const char *user, gid_t group, gid_t *groups, int *ngroups);
 ssize_t nonblock_read(int fd, void *buf, size_t count);
+int set_win_size(int fd, int rows, int columns);
 #endif


### PR DESCRIPTION
to support oci-1.0-rc5 this change is needed since
console size can be specified when the container is launched

Signed-off-by: Julio Montes <julio.montes@intel.com>