### PR TITLE
Move containers to their own PID namespace

### DIFF
--- a/src/container.c
+++ b/src/container.c
@@ -785,6 +785,7 @@ void hyper_cleanup_container(struct hyper_container *c, struct hyper_pod *pod)
 		perror("umount devpts failed");
 
 	close(c->ns);
+	close(c->pid_ns);
 	hyper_cleanup_container_portmapping(c, pod);
 	hyper_free_container(c);
 }

--- a/src/container.h
+++ b/src/container.h
@@ -34,6 +34,7 @@ struct hyper_container {
 	struct list_head	list;
 	struct hyper_exec	exec;
 	int			ns;
+	int			pid_ns;
 	uint32_t		code;
 
 	// configs

--- a/src/init.c
+++ b/src/init.c
@@ -333,15 +333,8 @@ out:
 // enter the sanbox and pass to the child, shouldn't call from the init process
 int hyper_enter_sandbox(struct hyper_pod *pod, int pidpipe)
 {
-	int ret = -1, pidns = -1, utsns = -1, ipcns = -1;
+	int ret = -1, utsns = -1, ipcns = -1;
 	char path[512];
-
-	sprintf(path, "/proc/%d/ns/pid", pod->init_pid);
-	pidns = open(path, O_RDONLY| O_CLOEXEC);
-	if (pidns < 0) {
-		perror("fail to open pidns of pod init");
-		goto out;
-	}
 
 	sprintf(path, "/proc/%d/ns/uts", pod->init_pid);
 	utsns = open(path, O_RDONLY| O_CLOEXEC);
@@ -357,32 +350,14 @@ int hyper_enter_sandbox(struct hyper_pod *pod, int pidpipe)
 		goto out;
 	}
 
-	if (setns(pidns, CLONE_NEWPID) < 0 ||
-	    setns(utsns, CLONE_NEWUTS) < 0 ||
+	if (setns(utsns, CLONE_NEWUTS) < 0 ||
 	    setns(ipcns, CLONE_NEWIPC) < 0) {
 		perror("fail to enter the sandbox");
 		goto out;
 	}
 
-	/* current process isn't in the pidns even setns(pidns, CLONE_NEWPID)
-	 * was called. fork() is needed, so that the child process will run in
-	 * the pidns, see man 2 setns */
-	ret = fork();
-	if (ret < 0) {
-		perror("fail to fork");
-		goto out;
-	} else if (ret > 0) {
-		fprintf(stdout, "create child process pid=%d in the sandbox\n", ret);
-		if (pidpipe > 0) {
-			hyper_send_type(pidpipe, ret);
-		}
-		_exit(0);
-	}
-
+	ret = 0;
 out:
-	if (pidns >= 0)
-		close(pidns);
-
 	if (ipcns >= 0)
 		close(ipcns);
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -661,6 +661,7 @@ static int hyper_parse_container(struct hyper_pod *pod, struct hyper_container *
 	c->exec.stderrev.fd = -1;
 	c->exec.ptyfd = -1;
 	c->ns = -1;
+	c->pid_ns = -1;
 	INIT_LIST_HEAD(&c->list);
 
 	next_container = toks[i].size;


### PR DESCRIPTION
This commit moves the creation of the PID namespace from the pod level
to the container level thus aligning more closely with the k8s/docker
expectation of what is shared.

By moving the container to its own namespace this means the hyperstart
init is not PID 1 inside the containers thus preventing escape from the
container fs to the pod fs via /proc/1/cwd.

This change works by moving the switch to the PID namespace and the
subsequent fork from hyper_enter_sandbox() to hyper_do_exec_cmd(). This
is necessary as hyper_enter_sandbox() is called with a temporary process
to setup the container rootfs and the first process created in a
namespace must persist.

The first time the container is entered a new PID namespace is created
otherwise the existing one is entered. The namespace fd is acquired by
hyper_run_process() by looking up the namespace on the pid of the first
process launched in the container.

When creating a new PID namespace (not for joining) it is necessary to
remount /proc so that only the new processes are visible.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>