### PR TITLE
Revert "Move containers to their own PID namespace"

### DIFF
--- a/src/container.c
+++ b/src/container.c
@@ -785,7 +785,6 @@ void hyper_cleanup_container(struct hyper_container *c, struct hyper_pod *pod)
 		perror("umount devpts failed");
 
 	close(c->ns);
-	close(c->pid_ns);
 	hyper_cleanup_container_portmapping(c, pod);
 	hyper_free_container(c);
 }

--- a/src/container.h
+++ b/src/container.h
@@ -34,7 +34,6 @@ struct hyper_container {
 	struct list_head	list;
 	struct hyper_exec	exec;
 	int			ns;
-	int			pid_ns;
 	uint32_t		code;
 
 	// configs

--- a/src/exec.c
+++ b/src/exec.c
@@ -6,7 +6,6 @@
 #include <sys/stat.h>
 #include <sys/epoll.h>
 #include <sys/ioctl.h>
-#include <sys/mount.h>
 #include <sys/wait.h>
 #include <sys/socket.h>
 #include <dirent.h>
@@ -479,7 +478,6 @@ static int hyper_setup_stdio_events(struct hyper_exec *exec, struct stdio_config
 static int hyper_do_exec_cmd(struct hyper_exec *exec, int pipe, struct stdio_config *io)
 {
 	struct hyper_container *c;
-	int ret;
 
 	if (hyper_enter_sandbox(exec->pod, pipe) < 0) {
 		perror("enter pidns of pod init failed");
@@ -497,43 +495,8 @@ static int hyper_do_exec_cmd(struct hyper_exec *exec, int pipe, struct stdio_con
 		perror("fail to enter container ns");
 		goto out;
 	}
-
-	/* c->pid_ns is set in hyper_run_process based off the pid sent over the pipe */
-	if (c->pid_ns > 0) {
-		if (setns(c->pid_ns, CLONE_NEWPID) < 0) {
-			perror("fail to enter container pid ns");
-			goto out;
-		}
-	} else {
-		if (unshare(CLONE_NEWPID) < 0) {
-			perror("failed to create new pid ns");
-			goto out;
-		}
-	}
-
-	/* current process isn't in the pidns even though setns(pidns, CLONE_NEWPID)
-	 * was called. fork() is needed, so that the child process will run in
-	 * the pidns, see man 2 setns */
-	ret = fork();
-	if (ret < 0) {
-		perror("failed to fork");
-		goto out;
-	} else if (ret > 0) {
-		fprintf(stdout, "created child process pid=%d in the sandbox\n", ret);
-		if (pipe > 0) {
-			hyper_send_type(pipe, ret);
-		}
-		_exit(0);
-	}
-
 	if (chdir("/") < 0) {
 		perror("fail to change to the root of the rootfs");
-		goto out;
-	}
-
-	/* iff creating new pid namespace remount /proc inside */
-	if (c->pid_ns == -1 && mount("proc", "/proc", "proc", MS_NOSUID | MS_NODEV | MS_NOEXEC, NULL) < 0) {
-		perror("failed to mount /proc after pid namespace switch");
 		goto out;
 	}
 
@@ -649,8 +612,6 @@ int hyper_run_process(struct hyper_exec *exec)
 	int pid, ret = -1;
 	uint32_t type;
 	struct stdio_config io = {-1, -1,-1, -1,-1, -1};
-	struct hyper_container *c;
-	char path[128];
 
 	if (exec->argv == NULL || exec->seq == 0 || exec->container_id == NULL || strlen(exec->container_id) == 0) {
 		fprintf(stderr, "cmd is %p, seq %" PRIu64 ", container %s\n",
@@ -685,21 +646,6 @@ int hyper_run_process(struct hyper_exec *exec)
 	if (hyper_get_type(pipe[0], &type) < 0 || (int)type < 0) {
 		fprintf(stderr, "run process failed\n");
 		goto close_tty;
-	}
-
-	c = hyper_find_container(exec->pod, exec->container_id);
-	if (c == NULL) {
-		fprintf(stderr, "can not find container %s\n", exec->container_id);
-		goto out;
-	}
-
-	if (c->pid_ns < 0) {
-		sprintf(path, "/proc/%d/ns/pid", type);
-		c->pid_ns = open(path, O_RDONLY | O_CLOEXEC);
-		if (c->pid_ns < 0) {
-			perror("open container pid ns failed");
-			goto close_tty;
-		}
 	}
 
 	if (hyper_setup_stdio_events(exec, &io) < 0) {

--- a/src/init.c
+++ b/src/init.c
@@ -333,8 +333,15 @@ out:
 // enter the sanbox and pass to the child, shouldn't call from the init process
 int hyper_enter_sandbox(struct hyper_pod *pod, int pidpipe)
 {
-	int ret = -1, utsns = -1, ipcns = -1;
+	int ret = -1, pidns = -1, utsns = -1, ipcns = -1;
 	char path[512];
+
+	sprintf(path, "/proc/%d/ns/pid", pod->init_pid);
+	pidns = open(path, O_RDONLY| O_CLOEXEC);
+	if (pidns < 0) {
+		perror("fail to open pidns of pod init");
+		goto out;
+	}
 
 	sprintf(path, "/proc/%d/ns/uts", pod->init_pid);
 	utsns = open(path, O_RDONLY| O_CLOEXEC);
@@ -350,14 +357,32 @@ int hyper_enter_sandbox(struct hyper_pod *pod, int pidpipe)
 		goto out;
 	}
 
-	if (setns(utsns, CLONE_NEWUTS) < 0 ||
+	if (setns(pidns, CLONE_NEWPID) < 0 ||
+	    setns(utsns, CLONE_NEWUTS) < 0 ||
 	    setns(ipcns, CLONE_NEWIPC) < 0) {
 		perror("fail to enter the sandbox");
 		goto out;
 	}
 
-	ret = 0;
+	/* current process isn't in the pidns even setns(pidns, CLONE_NEWPID)
+	 * was called. fork() is needed, so that the child process will run in
+	 * the pidns, see man 2 setns */
+	ret = fork();
+	if (ret < 0) {
+		perror("fail to fork");
+		goto out;
+	} else if (ret > 0) {
+		fprintf(stdout, "create child process pid=%d in the sandbox\n", ret);
+		if (pidpipe > 0) {
+			hyper_send_type(pidpipe, ret);
+		}
+		_exit(0);
+	}
+
 out:
+	if (pidns >= 0)
+		close(pidns);
+
 	if (ipcns >= 0)
 		close(ipcns);
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -661,7 +661,6 @@ static int hyper_parse_container(struct hyper_pod *pod, struct hyper_container *
 	c->exec.stderrev.fd = -1;
 	c->exec.ptyfd = -1;
 	c->ns = -1;
-	c->pid_ns = -1;
 	INIT_LIST_HEAD(&c->list);
 
 	next_container = toks[i].size;


### PR DESCRIPTION
Julio noticed a strange speed regression on exec with this commit.
Revert for now.

This reverts commit 9bf5e1b058433094b6875610ff075a14ea394278.

Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>