### PR TITLE
Set msize for 9p mounting

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -464,8 +464,12 @@ static int hyper_setup_shared(struct hyper_pod *pod)
 		return -1;
 	}
 
+	// Adding 524288 (512K) value to msize, provides
+	// an enhancement in I/O storage operations.
+	// This value was tested using different block sizes
+	// and I/O operations.
 	if (mount(pod->share_tag, SHARED_DIR, "9p",
-		  MS_MGC_VAL| MS_NODEV, "trans=virtio") < 0) {
+		  MS_MGC_VAL| MS_NODEV, "trans=virtio,msize=524288") < 0) {
 
 		perror("fail to mount shared dir");
 		return -1;


### PR DESCRIPTION
By adding the msize value (524288 bytes)
provides an enhancement in I/O storage operations.
The following results are from I/O operations such as:
read, write, random read etc...,using different block
sizes, where the x results express how many times is better.

## Read

| bs    | random | linear  |
| ----- | ------ | ------- |
| 64K   | 6x     | 7x      |
| 256K  | 13x    | 17x     |
| 512K  | 16x    | 13x     |
| 64MB  | 14x    | 14x     |
| 256MB | 15x    | 15x     |
| 512MB | 14x    | 15x     |

## Write

| bs    | random | linear  |
| ----- | ------ | ------- |
| 64K   | 3x     | 3x      |
| 256K  | 3x     | 3x      |
| 512K  | 3x     | 3x      |
| 64MB  | 3x     | 3x      |
| 256MB | 3x     | 3x      |
| 512MB | 3x     | 3x      |

Signed-off-by: Mario Alfredo Carrillo Arevalo <mario.alfredo.c.arevalo@intel.com>