### PR TITLE
docs: README: Add build instructions for Clear Containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,10 @@ If you want to get the boot disk file for VirtualBox, please reconfigure with fl
 
 Then you can find `hyper-vbox-bootimage.iso` in the build directory. Booting from this iso will
 bring you to the hyper world.
+
+### Building for [Intel](https://www.intel.com) [Clear Containers](https://clearlinux.org/features/intel%C2%AE-clear-containers)
+
+Clear Containers uses hyperstart in 'application mode', that is, not as the init process. To build hyperstart in this mode you need to pass some extra arguments to `autogen.sh`.
+
+    > ./autogen.sh
+    > ./configure --enable-daemon


### PR DESCRIPTION
Clear Containers requires hyperstart to be built in application mode,
that is, not to be run as 'init', but as a standalone app.
Supply the instructions on how to do this.

Signed-off-by: Graham Whaley <graham.whaley@intel.com>