### PR TITLE
Do not fail if scanning scsi devices returns failure

### DIFF
--- a/src/container.c
+++ b/src/container.c
@@ -534,7 +534,6 @@ static int hyper_setup_container_rootfs(void *data)
 
 	if (container->fstype && hyper_rescan_scsi() < 0) {
 		fprintf(stdout, "rescan scsi failed\n");
-		goto fail;
 	}
 
 	if (mount("", "/", NULL, MS_SLAVE|MS_REC, NULL) < 0) {


### PR DESCRIPTION
In case a file system type is provided for a container which
indicates a device to be used for the container rootfs,
hyperstart scans the scsi devices. Do not fail if the scsi scan
fails.The device to be used may not be a scsi drive and scsi support
may be be built in tke kernel. Do not fail here.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>